### PR TITLE
Consultas por camo

### DIFF
--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -35,15 +35,21 @@ class MongoLib {
 
   // Crud
   /**
-   *
-   * @param {string} collection collection to connect to database
-   * @param {Object} query query to find matches
-   * @param {number} limit  returns specific number of results
-   * @returns {Array} data
+   * Regresa los registros dependiendo la query y el límite seleccionado
+   * @param {string} collection colleción a la cuál se conectará la base de datos
+   * @param {Object} query query la cuál hace match con los campos y encuentra registros
+   * @param {number} limit limite de registros que se mostrarán
+   * @param {Object} fields campos que se mostrarán
+   * @returns {Array} datos que regresa
    */
-  getAll(collection, query, limit = 0) {
+  getAll(collection, query, limit = 0, fields = {}) {
     return this.connect().then((db) => {
-      return db.collection(collection).find(query).limit(limit).toArray();
+      return db
+        .collection(collection)
+        .find(query)
+        .project(fields)
+        .limit(limit)
+        .toArray();
     });
   }
 

--- a/services/app.js
+++ b/services/app.js
@@ -3,9 +3,17 @@ const MongoLib = require("../lib/mongo");
 function getQuerySearch(tags) {
   let query = {};
   for (const field in tags) {
-    if (field !== "limit") {
+    if (field !== "limit" && field !== "fields") {
       query[field] = { $regex: `.*${tags[field]}.*` };
     }
+  }
+  return query;
+}
+
+function getQueryFields(fields) {
+  let query = {};
+  for (let i = 0; i < fields.length; i++) {
+    query[fields[i]] = 1;
   }
   return query;
 }
@@ -18,7 +26,15 @@ class AppService {
 
   async getAllData(tags, limit) {
     const query = tags && getQuerySearch(tags);
-    const data = await this.mongoDB.getAll(this.collection, query, limit);
+    const { fields } = tags;
+    const queryFields = fields ? getQueryFields(fields.split(" ")) : {};
+
+    const data = await this.mongoDB.getAll(
+      this.collection,
+      query,
+      limit,
+      queryFields
+    );
     return data || [];
   }
 


### PR DESCRIPTION
Ahora ya podemos hacer consultas de este tipo
Donde fields indica los campos deseados separados por coma

{{url}}/api/users?fields=name nickname&name=ar&email=com&limit=4

**This PR Addresses:**  
[E23-20 Consulta por campos](https://look-app-me.atlassian.net/browse/E23-20)  


<sup> Created from VS Code using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>